### PR TITLE
Add Netflix Terms of Service

### DIFF
--- a/declarations/Netflix.json
+++ b/declarations/Netflix.json
@@ -1,0 +1,14 @@
+{
+  "name": "Netflix",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://help.netflix.com/legal/privacy",
+      "select": [
+        ".global-content > .container"
+      ],
+      "remove": [
+        ".breadcrumb-container"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### [🔎 Inspect this declaration suggestion](http://99.80.73.127:3000/service?destination=fabianospinelli%2Ftest_contrib-declarations&json=%7B%22name%22%3A%22Netflix%22%2C%22documents%22%3A%7B%22Terms%20of%20Service%22%3A%7B%22fetch%22%3A%22https%3A%2F%2Fhelp.netflix.com%2Flegal%2Fprivacy%22%2C%22select%22%3A%5B%22.global-content%20%3E%20.container%22%5D%2C%22remove%22%3A%5B%22.breadcrumb-container%22%5D%7D%7D%7D&expertMode=true)

Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, you should check:

- [ ] The suggested document **matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.
- [ ] **The service name `Netflix` matches what you see on the web page**, and it complies with the [guidelines](https://docs.opentermsarchive.org/guidelines/declaring/#service-name).
- [ ] **The service ID `Netflix` (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://docs.opentermsarchive.org/guidelines/declaring/#service-id).
- [ ] The terms type `Terms of Service` is appropriate for this document: if you read out loud the [terms type tryptich](https://github.com/OpenTermsArchive/terms-types/blob/main/termsTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.
- [ ] **Selectors are:**
  - **stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
  - **simple**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class or a tag).
- [ ] **Generated version** is:
  - **relevant**: it is not just a series of links, for example.
  - **readable**: it is complete and not mangled.
  - **clean**: it does not contain navigation links, unnecessary images, or extra content.

- - -

If no document type seems appropriate for this document yet it is relevant to track in this instance, please check if there is already an [open discussion](https://github.com/OpenTermsArchive/engine/discussions) about such a type and reference your case there, or open a new discussion if not.

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪

- - -

_This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can load it [on your local instance](http://localhost:3000/service?destination=fabianospinelli%2Ftest_contrib-declarations&json=%7B%22name%22%3A%22Netflix%22%2C%22documents%22%3A%7B%22Terms%20of%20Service%22%3A%7B%22fetch%22%3A%22https%3A%2F%2Fhelp.netflix.com%2Flegal%2Fprivacy%22%2C%22select%22%3A%5B%22.global-content%20%3E%20.container%22%5D%2C%22remove%22%3A%5B%22.breadcrumb-container%22%5D%7D%7D%7D&expertMode=true) if you have one set up._
