### PR TITLE
Update BYD Privacy Policy

### DIFF
--- a/declarations/BYD.history.json
+++ b/declarations/BYD.history.json
@@ -1,0 +1,12 @@
+{
+  "Privacy Policy": [
+    {
+      "fetch": "https://www.byd.com/en/privacy",
+      "select": [
+        ".rich-text-area"
+      ],
+      "executeClientScripts": true,
+      "validUntil": "to-be-determined"
+    }
+  ]
+}

--- a/declarations/BYD.json
+++ b/declarations/BYD.json
@@ -4,8 +4,9 @@
     "Privacy Policy": {
       "fetch": "https://www.byd.com/en/privacy",
       "select": [
-        "p:nth-child(3)"
-      ]
+        ".rich-text-area"
+      ],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/BYD.json
+++ b/declarations/BYD.json
@@ -4,9 +4,8 @@
     "Privacy Policy": {
       "fetch": "https://www.byd.com/en/privacy",
       "select": [
-        ".rich-text-area"
-      ],
-      "executeClientScripts": true
+        "p:nth-child(3)"
+      ]
     }
   }
 }


### PR DESCRIPTION
### [🔎 Inspect this declaration update suggestion](http://99.80.73.127:3000/service?destination=fabianospinelli%2Ftest_contrib-declarations&json=%7B%22name%22%3A%22BYD%22%2C%22documents%22%3A%7B%22Privacy%20Policy%22%3A%7B%22fetch%22%3A%22https%3A%2F%2Fwww.byd.com%2Fen%2Fprivacy%22%2C%22select%22%3A%5B%22p%3Anth-child%283%29%22%5D%7D%7D%7D&expertMode=true)

Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, you should check:

- [ ] **Selectors are:**
  - **stable**: as much as possible, the CSS selectors are meaningful and specific (e.g. `.tos-content` rather than `.ab23 .cK_drop > div`).
  - **simple**: the CSS selectors do not have unnecessary specificity (e.g. if there is an ID, do not add a class or a tag).
- [ ] **Generated version** is:
  - **relevant**: it is not just a series of links, for example.
  - **readable**: it is complete and not mangled.
  - **clean**: it does not contain navigation links, unnecessary images, or extra content.
- [ ] **`validUntil` date is correctly input** in the history file. To get that date, you can use the following method. In all cases where a date is to be obtained from the GitHub user interface, you can obtain the exact datetime by hovering your cursor over the date or using the developer tools to copy its `datetime` attribute.
  1. Find the date at which the problem was first encountered:
    - If there is one, find the first date at which an issue was opened claiming that the terms can not be tracked anymore.
    - If there is no issue, or if the version is wrong even though the terms can be extracted, [find the first version](https://github.com/fabianospinelli/test_contrib-versions/commits/main/BYD/Privacy%20Policy.md) with wrong data and obtain its date.
    - If the document can not be fetched anymore, [find the latest snapshot](https://github.com/fabianospinelli/test_contrib-snapshots/commits/main/BYD/Privacy%20Policy.html).
  2. Find the most recent snapshot that is strictly anterior to this date from the [snapshots database](https://github.com/fabianospinelli/test_contrib-snapshots/commits/main/BYD/Privacy%20Policy.html).
  3. Set the creation date of this snapshot as the `validUntil` date in the [history file](./files).

- - -

Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪


- - -

_This update suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can load it [on your local instance](http://localhost:3000/service?destination=fabianospinelli%2Ftest_contrib-declarations&json=%7B%22name%22%3A%22BYD%22%2C%22documents%22%3A%7B%22Privacy%20Policy%22%3A%7B%22fetch%22%3A%22https%3A%2F%2Fwww.byd.com%2Fen%2Fprivacy%22%2C%22select%22%3A%5B%22p%3Anth-child%283%29%22%5D%7D%7D%7D&expertMode=true) if you have one set up._
